### PR TITLE
Do not add saws to PoP in item rando

### DIFF
--- a/RandomizerMod/IC/Export.cs
+++ b/RandomizerMod/IC/Export.cs
@@ -22,6 +22,7 @@ namespace RandomizerMod.IC
             ItemChangerMod.Modules.Add<TrackerLog>();
             if (gs.MiscSettings.RandomizeNotchCosts) ItemChangerMod.Modules.Add<ItemChanger.Modules.NotchCostUI>();
             if (!gs.PoolSettings.GrimmkinFlames) ItemChangerMod.Modules.Get<ItemChanger.Modules.InventoryTracker>().TrackGrimmkinFlames = false;
+            if (gs.TransitionSettings.Mode == TransitionSettings.TransitionMode.RoomRandomizer) ItemChangerMod.Modules.Add<ItemChanger.Modules.ReversePathOfPainSaw>();
         }
 
 


### PR DESCRIPTION
Requires the corresponding ItemChanger change so that they're not enabled by default.