### PR TITLE
Require PRECISEMOVEMENT for Fungus2_06 coyote jump

### DIFF
--- a/RandomizerMod/Resources/Logic/transitions.json
+++ b/RandomizerMod/Resources/Logic/transitions.json
@@ -1885,7 +1885,7 @@
   {
     "sceneName": "Fungus2_06",
     "gateName": "right1",
-    "logic": "Fungus2_06[right1] | Fungus2_06 + (ACID | RIGHTDASH | WINGS | RIGHTCLAW | RIGHTSUPERDASH | AIRSTALL + AREASOUL | Fungus2_06[top1])",
+    "logic": "Fungus2_06[right1] | Fungus2_06 + (ACID | RIGHTDASH | WINGS | RIGHTCLAW + PRECISEMOVEMENT | RIGHTSUPERDASH | AIRSTALL + AREASOUL | Fungus2_06[top1])",
     "oneWayType": "TwoWay",
     "Name": "Fungus2_06[right1]"
   },


### PR DESCRIPTION
Getting over that acid pool and catching the right wall using claw and no other items requires a precisely-timed jump, probably requiring coyote frames.