### PR TITLE
Add missing item combo

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -537,7 +537,7 @@
   },
   {
     "name": "Wanderer's_Journal-Ancient_Basin",
-    "logic": "(Abyss_02[right1] | (Abyss_02[bot1] + (LEFTCLAW | WINGS))) + (RIGHTDASH | SPIKETUNNELS)"
+    "logic": "(Abyss_02[right1] | (Abyss_02[bot1] + (LEFTCLAW | WINGS))) + ((LEFTCLAW + RIGHTSUPERDASH) | RIGHTDASH | SPIKETUNNELS)"
   },
   {
     "name": "Wanderer's_Journal-Kingdom's_Edge_Entrance",


### PR DESCRIPTION
This was always my understanding of the "intended" way to get this item. [I asked in Discord](https://discord.com/channels/772964112908156938/822832351797182514/967872224805654588) and was told the reason this wasn't here already [was because in Rando 3 you actually couldn't reach it with the added platforms](https://discord.com/channels/772964112908156938/822832351797182514/967872788209741845). Since the platforms are now conditional based on whether you have claw or not, we can consider this check reachable with that combination of items.