### PR TITLE
Fix logic bug for Fungus2_17[right1]

### DIFF
--- a/RandomizerMod/Resources/Logic/transitions.json
+++ b/RandomizerMod/Resources/Logic/transitions.json
@@ -2081,7 +2081,7 @@
   {
     "sceneName": "Fungus2_17",
     "gateName": "right1",
-    "logic": "Fungus2_17[right1] | Fungus2_17 + RIGHTCLAW | LEFTCLAW + (RIGHTDASH | RIGHTSUPERDASH) | Fungus2_17[left1] + WINGS | Fungus2_17[bot1] + WINGS + ENEMYPOGOS",
+    "logic": "Fungus2_17[right1] | Fungus2_17 + (RIGHTCLAW | LEFTCLAW + (RIGHTDASH | RIGHTSUPERDASH)) | Fungus2_17[left1] + WINGS | Fungus2_17[bot1] + WINGS + ENEMYPOGOS",
     "oneWayType": "TwoWay",
     "Name": "Fungus2_17[right1]"
   },


### PR DESCRIPTION
There's a missing set of parenthesis here, which causes `LEFTCLAW + (RIGHTDASH | RIGHTSUPERDASH)` to erroneously put this gate in logic, without any actual access to Fungal.