### PR TITLE
Add profiler control calls as part of RandoController

### DIFF
--- a/RandomizerMod/Menu/ModMenu.cs
+++ b/RandomizerMod/Menu/ModMenu.cs
@@ -11,6 +11,9 @@ namespace RandomizerMod.Menu
             builder.AddButton(Localize("Open Log Folder"), null, () => RandomizerMenu.OpenFile(null, string.Empty, DirectoryOptions.RecentLogFolder));
             builder.AddButton(Localize("Open Helper Log"), null, () => RandomizerMenu.OpenFile(null, "HelperLog.txt", DirectoryOptions.RecentLogFolder));
             builder.AddButton(Localize("Open Tracker Log"), null, () => RandomizerMenu.OpenFile(null, "TrackerLog.txt", DirectoryOptions.RecentLogFolder));
+#if DEBUG
+            builder.AddButton(Localize("Reset Profiling Data"), null, () => RandomizerCore.Profiling.Reset());
+#endif
             return builder.CreateMenuScreen();
         }
     }

--- a/RandomizerMod/RC/RandoController.cs
+++ b/RandomizerMod/RC/RandoController.cs
@@ -47,10 +47,32 @@ namespace RandomizerMod.RC
         public void Run()
         {
             gs.Clamp();
+
+            rm.OnNewAttempt += () => Profiling.Revert();
+
+            Profiling.Revert();
             rb = new(gs, pm, rm);
             rb.Run(out stages, out ctx);
+            Profiling.Commit();
+
             randomizer = new(new Random(gs.Seed), ctx, stages, rm);
-            stagedPlacements = randomizer.Run();
+            try
+            {
+                stagedPlacements = randomizer.Run();
+            }
+            catch
+            {
+                Profiling.Revert();
+                LogDebug("Randomization failed. Profiling results for all attempts:");
+                Profiling.Log(true);
+                throw;
+            }
+
+            Profiling.Commit();
+            LogDebug("Randomization completed successfully. Profiling results for succeeded attempts:");
+            Profiling.Log();
+            LogDebug("Profiling results for all attempts:");
+            Profiling.Log(true);
             for (int i = 0; i < stagedPlacements.Count; i++)
             {
                 for (int j = 0; j < stagedPlacements[i].Length; j++)


### PR DESCRIPTION
As-implemented, this should basically never need to change.

At the start of setup, any stray staged changes are reverted. Changes are reverted and logged on every failure, and committed and logged on every successful attempt. Additionally, after a successful attempts, aggregated metrics from all succeeded and failed attempts are also logged. Metric data can be reset from the mod menu when compiled in Debug configuration.