### PR TITLE
Lurker logic fix for split cdash

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -249,7 +249,7 @@
   },
   {
     "name": "Simple_Key-Lurker",
-    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + RIGHTSUPERDASH)) + RIGHTCLAW + Defeated_Pale_Lurker"
+    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + SUPERDASH)) + RIGHTCLAW + Defeated_Pale_Lurker"
   },
   {
     "name": "Shopkeeper's_Key",

--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -249,7 +249,7 @@
   },
   {
     "name": "Simple_Key-Lurker",
-    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + SUPERDASH)) + RIGHTCLAW + Defeated_Pale_Lurker"
+    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + FULLSUPERDASH)) + RIGHTCLAW + Defeated_Pale_Lurker"
   },
   {
     "name": "Shopkeeper's_Key",

--- a/RandomizerMod/Resources/Logic/waypoints.json
+++ b/RandomizerMod/Resources/Logic/waypoints.json
@@ -226,7 +226,7 @@
   },
   {
     "name": "Defeated_Pale_Lurker",
-    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + SUPERDASH)) + RIGHTCLAW + COMBAT[Pale_Lurker]",
+    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + FULLSUPERDASH)) + RIGHTCLAW + COMBAT[Pale_Lurker]",
     "Stateless": true
   },
   {

--- a/RandomizerMod/Resources/Logic/waypoints.json
+++ b/RandomizerMod/Resources/Logic/waypoints.json
@@ -226,7 +226,7 @@
   },
   {
     "name": "Defeated_Pale_Lurker",
-    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + RIGHTSUPERDASH)) + RIGHTCLAW + COMBAT[Pale_Lurker]",
+    "logic": "GG_Lurker[left1] + (SWIM | RIGHTDASH | WINGS | (LEFTCLAW + SUPERDASH)) + RIGHTCLAW + COMBAT[Pale_Lurker]",
     "Stateless": true
   },
   {


### PR DESCRIPTION
Lurker stops cdashes & returns to her initial position after room reload, and left cdash is necessary to make it back to the left wall for right cdash.
All other standard methods to get to left wall also get to right wall, so we can just simplify RIGHTSUPERDASH to SUPERDASH

completely untested but should be safe probably :)