### PR TITLE
Add missing ENEMYPOGOS to tower of love vengefly skip

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -269,7 +269,7 @@
   },
   {
     "name": "Collector's_Map",
-    "logic": "Ruins2_11[right1] + (LEFTCLAW | RIGHTCLAW + (WINGS | RIGHTDASH | PRECISEMOVEMENT) | WINGS + COMPLEXSKIPS | $SHRIEKPOGO[5,before:AREASOUL]) + Defeated_Collector"
+    "logic": "Ruins2_11[right1] + (LEFTCLAW | RIGHTCLAW + (WINGS | RIGHTDASH | PRECISEMOVEMENT) | WINGS + COMPLEXSKIPS + ENEMYPOGOS | $SHRIEKPOGO[5,before:AREASOUL]) + Defeated_Collector"
   },
   {
     "name": "Mask_Shard-Brooding_Mawlek",


### PR DESCRIPTION
This is in the readme as a canonical example of complex skips. Tutorial_01[top2] is also listed for a similar skip and had the enemy pogo check so my assumption is it's not correct for the enemy pogo to be superceded here