### PR TITLE
Changed LocationDef reading source to support definitions made through EditLocationRequest.

### DIFF
--- a/RandomizerMod/RC/Requests/BuiltinRequests.cs
+++ b/RandomizerMod/RC/Requests/BuiltinRequests.cs
@@ -1655,7 +1655,8 @@ namespace RandomizerMod.RC
                 HashSet<string> multiSet = new();
                 foreach (string l in gb.Locations.EnumerateDistinct())
                 {
-                    if (Data.GetLocationDef(l) is LocationDef def && def.FlexibleCount) multiSet.Add(l);
+                    LocationDef def = new();
+                    if (rb.TryGetLocationDef(l, out def) && def.FlexibleCount) multiSet.Add(l);
                 }
                 if (multiSet.Count == 0) multiSet.Add(LocationNames.Sly);
                 string[] multi = multiSet.OrderBy(s => s).ToArray();


### PR DESCRIPTION
The current code returns null in the LocationDefs for any of them that was added with the EditLocationRequest function, which is how most connections add item & location definitions. This change shouldn't affect how base rando works while adding support for flexible locations in connections to have their share of padding.