### PR TITLE
Account for Traitor Lord wall attack in combat logic

### DIFF
--- a/RandomizerMod/Resources/Logic/macros.json
+++ b/RandomizerMod/Resources/Logic/macros.json
@@ -169,7 +169,7 @@
   "COMBAT[Watcher_Knights]": "BOSS",
   "COMBAT[Uumuu]": "AERIALMINIBOSS",
   "COMBAT[Nosk]": "BOSS",
-  "COMBAT[Traitor_Lord]": "BOSS",
+  "COMBAT[Traitor_Lord]": "BOSS + (FULLSHADOWDASH | QUAKE + PROFICIENTCOMBAT)",
   "COMBAT[Grimm]": "BOSS",
   "COMBAT[Collector]": "BOSS",
   "COMBAT[Hive_Knight]": "BOSS",


### PR DESCRIPTION
The potential inability to dodge this attack with only half cloak seems like an oversight in combat logic. Feel free to reject if you disagree.

The added logic is the same as what I use for radiance beam walls.