### PR TITLE
Add LEFTCLAW + ENEMYPOGOS to Mantis_Claw

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -53,7 +53,7 @@
   },
   {
     "name": "Mantis_Claw",
-    "logic": "Fungus2_14 + (LEFTDASH | WINGS | LEFTSUPERDASH + ANYCLAW | $SHADESKIP[2HITS] + ENEMYPOGOS | SPELLAIRSTALL + $CASTSPELL[1,1,before:ROOMSOUL])"
+    "logic": "Fungus2_14 + (LEFTDASH | WINGS | LEFTSUPERDASH + ANYCLAW | ($SHADESKIP[2HITS] | LEFTCLAW) + ENEMYPOGOS | SPELLAIRSTALL + $CASTSPELL[1,1,before:ROOMSOUL])"
   },
   {
     "name": "Crystal_Heart",


### PR DESCRIPTION
Adds the ability to get to the Mantis_Claw location using LEFTCLAW + ENEMYPOGOS.

This requirement works even in the worst-case scenario: Mantis Lords are defeated (enemies are passive) and the door down below is already open and you are entering from the right side of the room. Following the Nail upgrades by item acquisition requirements: This can be done with Wings (already accounted for). This can be done with 2 Nail upgrades and Left Claw (first video). This can be done with 3 Nail upgrades and Full Claw (second video).

https://discord.com/channels/731205301247803413/959203442570715176/1269768505301930077
https://discord.com/channels/731205301247803413/959203442570715176/1269772042727854090