### PR TITLE
Correct false positives in Defeated_Xero and Bench-Beast's_Den waypoints

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -1533,7 +1533,7 @@
   },
   {
     "name": "Geo_Rock-Beast's_Den_Above_Trilobite",
-    "logic": "Deepnest_Spider_Town[left1] + (WINGS + ANYCLAW | (FULLCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL]) + COMBAT[Left_Devout]) | Bench-Beast's_Den + (LEFTCLAW | RIGHTCLAW + WINGS | $SHRIEKPOGO[1,2,2])"
+    "logic": "Deepnest_Spider_Town[left1] + (FULLCLAW | WINGS + ANYCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL]) + COMBAT[Left_Devout] | Bench-Beast's_Den + (LEFTCLAW | RIGHTCLAW + WINGS | $SHRIEKPOGO[1,2,2])"
   },
   {
     "name": "Geo_Rock-Beast's_Den_Above_Trilobite_Dupe",

--- a/RandomizerMod/Resources/Logic/waypoints.json
+++ b/RandomizerMod/Resources/Logic/waypoints.json
@@ -231,7 +231,7 @@
   },
   {
     "name": "Defeated_Xero",
-    "logic": "RestingGrounds_02 + DREAMNAIL + COMBAT[Xero]",
+    "logic": "(RestingGrounds_02[top1] | RestingGrounds_02 + (ANYCLAW | WINGS | RIGHTSUPERDASH | BACKGROUNDPOGOS)) + DREAMNAIL + COMBAT[Xero]",
     "Stateless": true
   },
   {
@@ -804,7 +804,7 @@
   },
   {
     "name": "Bench-Beast's_Den",
-    "logic": "Deepnest_Spider_Town[left1] + (FULLCLAW | WINGS + ANYCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | ENEMYPOGOS + $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL] + COMBAT[Left_Devout]) + $BENCHRESET | WARPSTARTTOBENCH + Bench-Beast's_Den/"
+    "logic": "Deepnest_Spider_Town[left1] + (WINGS + ANYCLAW | (FULLCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | ENEMYPOGOS + $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL]) + COMBAT[Left_Devout]) + $BENCHRESET | WARPSTARTTOBENCH + Bench-Beast's_Den/"
   },
   {
     "name": "Bench-Basin_Toll",

--- a/RandomizerMod/Resources/Logic/waypoints.json
+++ b/RandomizerMod/Resources/Logic/waypoints.json
@@ -804,7 +804,7 @@
   },
   {
     "name": "Bench-Beast's_Den",
-    "logic": "Deepnest_Spider_Town[left1] + (WINGS + ANYCLAW | (FULLCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | ENEMYPOGOS + $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL]) + COMBAT[Left_Devout]) + $BENCHRESET | WARPSTARTTOBENCH + Bench-Beast's_Den/"
+    "logic": "Deepnest_Spider_Town[left1] + (WINGS + (LEFTCLAW + RIGHTSUPERDASH | RIGHTCLAW + (LEFTSUPERDASH | LEFTDASH)) | (FULLCLAW | WINGS + ANYCLAW | WINGS + COMPLEXSKIPS + $SHADESKIP[2HITS] | ENEMYPOGOS + $SHRIEKPOGO[2,before:ROOMSOUL] + $SHRIEKPOGO[2,before:ROOMSOUL]) + COMBAT[Left_Devout]) + $BENCHRESET | WARPSTARTTOBENCH + Bench-Beast's_Den/"
   },
   {
     "name": "Bench-Basin_Toll",


### PR DESCRIPTION
* Fixed issue where xero waypoint did not have traversal logic (likely holdover from rando3). Now matches logic from `Boss_Essence-Xero`
* Fixed issue where beast's den bench did not require devout combat when appropriate. Now matches the logic from `Geo_Rock-Beast's_Den_Above_Trilobite`