### PR TITLE
Require PRECISEMOVEMENT for Fungus2_06 coyote jump

### DIFF
--- a/RandomizerMod/Resources/Logic/transitions.json
+++ b/RandomizerMod/Resources/Logic/transitions.json
@@ -1864,7 +1864,7 @@
   {
     "sceneName": "Fungus2_06",
     "gateName": "top1",
-    "logic": "Fungus2_06[top1] | Fungus2_06 + (ACID | RIGHTDASH | WINGS | RIGHTCLAW + PRECISEMOVEMENT | RIGHTSUPERDASH | SPELLAIRSTALL + $CASTSPELL[before:AREASOUL,after:ROOMSOUL]) | Fungus2_06[right1]",
+    "logic": "Fungus2_06[top1] | Fungus2_06[right1]",
     "oneWayType": "TwoWay",
     "Name": "Fungus2_06[top1]"
   },

--- a/RandomizerMod/Resources/Logic/transitions.json
+++ b/RandomizerMod/Resources/Logic/transitions.json
@@ -1864,7 +1864,7 @@
   {
     "sceneName": "Fungus2_06",
     "gateName": "top1",
-    "logic": "Fungus2_06[top1] | Fungus2_06 + (ACID | RIGHTDASH | WINGS | RIGHTCLAW | RIGHTSUPERDASH | SPELLAIRSTALL + $CASTSPELL[before:AREASOUL,after:ROOMSOUL]) | Fungus2_06[right1]",
+    "logic": "Fungus2_06[top1] | Fungus2_06 + (ACID | RIGHTDASH | WINGS | RIGHTCLAW + PRECISEMOVEMENT | RIGHTSUPERDASH | SPELLAIRSTALL + $CASTSPELL[before:AREASOUL,after:ROOMSOUL]) | Fungus2_06[right1]",
     "oneWayType": "TwoWay",
     "Name": "Fungus2_06[top1]"
   },


### PR DESCRIPTION
The same change was made a while ago https://github.com/homothetyhk/RandomizerMod/commit/f45f4fb94783e31b8f592e2abad65f1f783bc71a but it did not account for the fact that reaching the upper transition also needs this change. Which meant that it assumed you could reach the upper transition which implied access to the transition that had PRECISEMOVEMENT added.