### PR TITLE
Fix false positive in waterways left geo rock

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -2009,7 +2009,7 @@
   },
   {
     "name": "Geo_Rock-Waterways_Left",
-    "logic": "Waterways_04b[left1] | Waterways_04b[right1] + (WINGS | LEFTDASH | SWIM | (RIGHTCLAW + RIGHTDASH + LEFTSUPERDASH)) | Waterways_04b[right2] + (WINGS | (LEFTCLAW + ENEMYPOGOS + DANGEROUSSKIPS)) + (LEFTCLAW | ENEMYPOGOS) + (SWIM | (LEFTSUPERDASH + RIGHTCLAW))"
+    "logic": "Waterways_04b[left1] + (PRECISEMOVEMENT | RIGHTDASH | RIGHTSUPERDASH | ANYCLAW | ENEMYPOGOS | SPELLAIRSTALL + $CASTSPELL[after:ROOMSOUL] | $TAKEDAMAGE) | Waterways_04b[right1] + (WINGS | LEFTDASH | SWIM | (RIGHTCLAW + RIGHTDASH + LEFTSUPERDASH)) | Waterways_04b[right2] + (WINGS | (LEFTCLAW + ENEMYPOGOS + DANGEROUSSKIPS)) + (LEFTCLAW | ENEMYPOGOS) + (SWIM | (LEFTSUPERDASH + RIGHTCLAW))"
   },
   {
     "name": "Geo_Rock-Waterways_East",


### PR DESCRIPTION
Coming from the left, there is a wide gap which requires a coyote jump to cross; this should be precise movement (apparently it may also require a good subpixel). Adding appropriate skips and movement to cross the gap