### PR TITLE
Correct shade skip unit tests

### DIFF
--- a/RandomizerModTests/StateVariables/ShadeSkipVariableTests.cs
+++ b/RandomizerModTests/StateVariables/ShadeSkipVariableTests.cs
@@ -31,7 +31,7 @@ namespace RandomizerModTests.StateVariables
         public void CannotShadeSkipWithUsedState()
         {
             StateModifier sm = (StateModifier)Fix.LM.GetVariableStrict("$SHADESKIP");
-            ProgressionManager pm = Fix.GetProgressionManager(new());
+            ProgressionManager pm = Fix.GetProgressionManager(ShadeskipPMBase);
             LazyStateBuilder lsb = Fix.GetState(new() { ["USEDSHADE"] = 1 });
 
             IEnumerable<LazyStateBuilder> result = sm.ModifyState(null, pm, lsb);
@@ -39,10 +39,10 @@ namespace RandomizerModTests.StateVariables
         }
 
         [Fact]
-        public void CannotShadeSkipWithCharm36()
+        public void CannotShadeSkipWithVoidHeartEquipped()
         {
             StateModifier sm = (StateModifier)Fix.LM.GetVariableStrict("$SHADESKIP");
-            ProgressionManager pm = Fix.GetProgressionManager(new());
+            ProgressionManager pm = Fix.GetProgressionManager(ShadeskipPMBase);
             LazyStateBuilder lsb = Fix.GetState(new() { ["CHARM36"] = 1 });
 
             IEnumerable<LazyStateBuilder> result = sm.ModifyState(null, pm, lsb);
@@ -53,7 +53,7 @@ namespace RandomizerModTests.StateVariables
         public void CannotShadeSkipWithMaxSoulRequirement()
         {
             StateModifier sm = (StateModifier)Fix.LM.GetVariableStrict("$SHADESKIP");
-            ProgressionManager pm = Fix.GetProgressionManager(new());
+            ProgressionManager pm = Fix.GetProgressionManager(ShadeskipPMBase);
             LazyStateBuilder lsb = Fix.GetState(new() { ["REQUIREDMAXSOUL"] = 67 });
 
             IEnumerable<LazyStateBuilder> result = sm.ModifyState(null, pm, lsb);


### PR DESCRIPTION
A few $SHADESKIP unit tests use an empty PM, rather than one with shade skips enabled. As such they don't test what they claim to. This PR fixes this. I also renamed the charm36 test for additional clarity why this is an interesting test case for a hypothetical reader who doesn't know all the charm IDs.

I did not actually run the tests as I made this quickly from the web on mobile. So hopefully they still pass