### PR TITLE
add 2xshrogo+rightclaw to vanilla path to broken vessel

### DIFF
--- a/RandomizerMod/Resources/Logic/transitions.json
+++ b/RandomizerMod/Resources/Logic/transitions.json
@@ -3673,7 +3673,7 @@
   {
     "sceneName": "Abyss_20",
     "gateName": "top1",
-    "logic": "Abyss_20[top1] | Abyss_20[top2] + (LEFTCLAW | ENEMYPOGOS + WINGS)",
+    "logic": "Abyss_20[top1] | Abyss_20[top2] + (LEFTCLAW | ENEMYPOGOS + WINGS | RIGHTCLAW + $SHRIEKPOGO[2])",
     "oneWayType": "TwoWay",
     "Name": "Abyss_20[top1]"
   },


### PR DESCRIPTION
[2025-08-28 19-51-21.webm](https://github.com/user-attachments/assets/1e7e4423-caae-464b-b9a8-5b2bcf787474)
could probably have `before:AREASOUL,after:AREASOUL` like the opposite direction but I didn't want to overpromise