### PR TITLE
Adjust logic for Resting Grounds Grub + Geo Rock

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -885,7 +885,7 @@
   },
   {
     "name": "Grub-Resting_Grounds",
-    "logic": "RestingGrounds_10 + (LEFTCLAW | WINGS | (ENEMYPOGOS + RIGHTCLAW)) + UPWALLBREAK"
+    "logic": "RestingGrounds_10 + (LEFTCLAW | WINGS | ENEMYPOGOS + DANGEROUSSKIPS + RIGHTCLAW) + UPWALLBREAK"
   },
   {
     "name": "Grub-Crystal_Peak_Below_Chest",
@@ -1925,7 +1925,7 @@
   },
   {
     "name": "Geo_Rock-Resting_Grounds_Catacombs_Grub",
-    "logic": "RestingGrounds_10 + (LEFTCLAW | WINGS | (ENEMYPOGOS + RIGHTCLAW)) + UPWALLBREAK"
+    "logic": "RestingGrounds_10 + (LEFTCLAW | WINGS | ENEMYPOGOS + DANGEROUSSKIPS + RIGHTCLAW) + UPWALLBREAK"
   },
   {
     "name": "Geo_Rock-Resting_Grounds_Catacombs_Left_Dupe",


### PR DESCRIPTION
If you have right claw and are willing to pogo an entombed husk, it's not difficult to get up to the area with a grub and a geo rock in RestingGrounds_10.