### PR TITLE
Fixes for King_Fragment location logic

### DIFF
--- a/RandomizerMod/Resources/Logic/locations.json
+++ b/RandomizerMod/Resources/Logic/locations.json
@@ -201,7 +201,7 @@
   },
   {
     "name": "King_Fragment",
-    "logic": "White_Palace_09[right1] + (LEFTSUPERDASH + (FULLCLAW | WINGS) | RIGHTCLAW + LEFTDASH + OBSCURESKIPS + PRECISEMOVEMENT + ($SHRIEKPOGO[1,1,1,1,1] | LEFTSHARPSHADOW + $SHRIEKPOGO[1,1,1,1]))"
+    "logic": "White_Palace_09[right1] + (LEFTSUPERDASH + (FULLCLAW | WINGS) | (RIGHTCLAW + LEFTDASH + OBSCURESKIPS + PRECISEMOVEMENT + ($SHRIEKPOGO[1,1,1,1,1] | LEFTSHARPSHADOW + $SHRIEKPOGO[1,1,1,1])))"
   },
   {
     "name": "Void_Heart",


### PR DESCRIPTION
I noticed I could get easily get to the King Fragment with just LEFTSUPERDASH + FULLCLAW, but was getting it marked on the map as being out of logic.

This should fix that particular case. That said, I'm not sure about the bits from RIGHTCLAW onward since I don't think I understand what that skip entails - so definitely lemme know if that part still makes sense.