### PR TITLE
fix: add Tuk egg location to the pool

### DIFF
--- a/RandomizerMod/RandomizerMod.csproj
+++ b/RandomizerMod/RandomizerMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyTitle>RandomizerMod</AssemblyTitle>
     <RootNamespace>RandomizerMod</RootNamespace>
-    <VersionPrefix>4.1.6</VersionPrefix>
+    <VersionPrefix>4.1.7</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>preview</LangVersion>
     <Deterministic>true</Deterministic>

--- a/RandomizerMod/RandomizerMod.csproj
+++ b/RandomizerMod/RandomizerMod.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyTitle>RandomizerMod</AssemblyTitle>
     <RootNamespace>RandomizerMod</RootNamespace>
-    <VersionPrefix>4.1.7</VersionPrefix>
+    <VersionPrefix>4.1.6</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>preview</LangVersion>
     <Deterministic>true</Deterministic>

--- a/RandomizerMod/Resources/Data/pools.json
+++ b/RandomizerMod/Resources/Data/pools.json
@@ -1185,6 +1185,10 @@
       },
       {
         "item": "Rancid_Egg",
+        "location": "Rancid_Egg-Tuk_Defender's_Crest"
+      },
+      {
+        "item": "Rancid_Egg",
         "location": "Sly"
       }
     ]


### PR DESCRIPTION
This PR adds the vanilla location for the Tuk Defender's Crest rancid egg to the item pool, so it is included in randomization when the rancid egg setting is on.

I'm not super confident about how all of this works (and this is my first time contributing to anything open source), so please let me know if I'm off-base!

Surfaced this via [an issue on the HK archipelago](https://github.com/ArchipelagoMW-HollowKnight/Archipelago.HollowKnight/issues/140), and confirmed the bug in my own game with a normal (non AP) randomizer.